### PR TITLE
chore: add setup info to readme. Tweak marketing page styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # Craft Lab App
 
 This app is very in progress, but feel free to poke around!
+
+This project was scaffolded using the
+[Epic Stack](https://github.com/epicweb-dev/epic-stack/tree/main/docs). Check
+out the docs for more detail on the project architecture and setup.
+
+## Getting started
+
+To get started:
+
+1. Install dependencies by running `npm install`
+1. Run the setup script with `npm run setup`
+1. Run the app with `npm run dev`

--- a/app/routes/_marketing+/index.tsx
+++ b/app/routes/_marketing+/index.tsx
@@ -159,16 +159,21 @@ export default function Index() {
 	return (
 		<main className="grid h-full grid-cols-[1fr_40px_auto_40px_1fr]">
 			<div></div>
-			<div className="bg-diagonal -mx-px border-x"></div>
-			<div className="self-center">
-				<div className={clsx(gridLines, 'relative flex items-center gap-2')}>
+			<div className="-mx-px border-x bg-diagonal"></div>
+			<div className="max-w-2xl self-center">
+				<div
+					className={clsx(
+						gridLines,
+						'relative flex items-center gap-2 px-2 py-1',
+					)}
+				>
 					<Logo seed={seed} className="h-auto w-8" />
-					<p className="font-bold">Craft Lab</p>
+					<p className="text-2xl font-bold">Craft Lab</p>
 				</div>
-				<h1 className={clsx(gridLines, 'relative mt-8 font-bold')}>
+				<h1 className={clsx(gridLines, 'relative mt-8 px-2 py-1 font-bold')}>
 					# A community for Design Engineers by Design Engineers.
 				</h1>
-				<p className={clsx(gridLines, 'relative mt-3')}>
+				<p className={clsx(gridLines, 'relative mt-3 px-2 py-1')}>
 					There are only <span className="underline">8</span> spots left for the
 					alpha group to help get this space off of the ground. Get on the
 					waitlist and let's chat 👇
@@ -176,7 +181,7 @@ export default function Index() {
 				<Form
 					method="POST"
 					{...getFormProps(form)}
-					className={clsx(gridLines, 'relative mt-6')}
+					className={clsx(gridLines, 'relative mt-6 px-2 pb-2 pt-1')}
 				>
 					<HoneypotInputs />
 					<Field
@@ -204,7 +209,7 @@ export default function Index() {
 					</StatusButton>
 				</Form>
 			</div>
-			<div className="bg-diagonal -mx-px border-x"></div>
+			<div className="-mx-px border-x bg-diagonal"></div>
 			<div></div>
 		</main>
 	)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,10 @@
 {
-  "name": "craft-lab",
+  "name": "the-craft-lab",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "craft-lab",
-      "license": "MIT",
+      "name": "the-craft-lab",
       "dependencies": {
         "@conform-to/react": "^1.0.4",
         "@conform-to/zod": "^1.0.4",


### PR DESCRIPTION
Adds setup instructions to the README and a link to the Epic Stack repo. 

Also adds some additional padding to the marketing page sections and a max width. More subjective of a change, so happy to discuss.

## Screenshots
![Screenshot 2024-04-11 at 9 21 12 AM](https://github.com/designgineers/craft-lab/assets/12838032/aaf8aa88-8512-49ad-a7bf-9086be855c05)


